### PR TITLE
Updating help message to string and ActionCallback.

### DIFF
--- a/examples/example1.cpp
+++ b/examples/example1.cpp
@@ -32,13 +32,11 @@ bool validation(int x) {
     return true;
 }
 
-// help callback
-void gallop_help(std::string command_name) {
-    std::cout << "The horses, they be a galloping" << std::endl;
-}
+// help message
+std::string gallop_help = "The horses, they be galloping\n";
 
 // action callback
-int gallop(std::string command_name, std::vector<std::string> arguments) {
+int gallop(std::vector<std::string> arguments) {
     for (int i = 0; i < GetFlag<int>("ponies"); i++) {
         if (!GetFlag<int>("tired")) {
             std::cout << "Galloping into the night!" << std::endl;


### PR DESCRIPTION
Help mesasge must be a string; ActionCallback does not take the command
name as argument.
