### PR TITLE
(PEG-109) - HorseWhisperer fails to parse negative arity

### DIFF
--- a/examples/example1.cpp
+++ b/examples/example1.cpp
@@ -17,6 +17,7 @@
         ./example gallop --ponies 5
         ./example gallop --ponies 6
         ./example gallop --ponies 5 --tired
+        ./example trot 'elegant dancer' 'drunk panda'
 */
 #include "../include/horsewhisperer/horsewhisperer.h"
 #include <string>
@@ -32,10 +33,11 @@ bool validation(int x) {
     return true;
 }
 
-// help message
+// help messages
 std::string gallop_help = "The horses, they be a galloping\n";
+std::string trot_help = "The horses, they be trotting in some way\n";
 
-// action callback
+// gallop callback
 int gallop(std::vector<std::string> arguments) {
     for (int i = 0; i < GetFlag<int>("ponies"); i++) {
         if (!GetFlag<int>("tired")) {
@@ -43,6 +45,14 @@ int gallop(std::vector<std::string> arguments) {
         } else {
             std::cout << "The pony is too tired to gallop." << std::endl;
         }
+    }
+    return 0;
+}
+
+// trot callback
+int trot(std::vector<std::string> arguments) {
+    for (auto mode : arguments) {
+        std::cout << "Trotting like a " << mode << std::endl;
     }
     return 0;
 }
@@ -57,8 +67,19 @@ int main(int argc, char* argv[]) {
     // Define global flags
     DefineGlobalFlag<int>("ponies", "all the ponies", 1, validation);
 
+    // Define action: gallop
     DefineAction("gallop", 0, false, "make the ponies gallop", gallop_help, gallop);
     DefineActionFlag<bool>("gallop", "tired", "are the horses tired?", false, nullptr);
-    Parse(argc, argv);
+
+    // Define action: trot (at least two arguments are required)
+    DefineAction("trot", -2, false, "make the ponies trot in some way", trot_help, trot);
+
+    // Parse command line arguments
+    if (!Parse(argc, argv)) {
+        std::cout << "Failed to parse the command line input.\n";
+        return 1;
+    }
+
+    // Start execution
     return Start();
 }

--- a/test/system_test_runner.sh
+++ b/test/system_test_runner.sh
@@ -25,6 +25,12 @@ check_strings() {
   fi
 }
 
+check_num_lines() {
+  if [ $1 -ne $2 ]; then
+    exit $EXIT_FAILURE
+  fi
+}
+
 # help: we expect the usage message
 USAGE_LABEL=`"$EXAMPLE" --help | head -n 1 | awk '{print $1}'`
 check_strings "$USAGE_LABEL" 'Usage:'
@@ -39,10 +45,22 @@ check_strings "$ACTION_MSG" 'Galloping'
 
 # global flag: we expect the above message 4 times
 MSG_NUM=`"$EXAMPLE" gallop --ponies 4 | awk '{ if ( $1 ~ /Galloping/ ) {print $1} }' | wc -l`
-if [ $MSG_NUM -ne 4 ]; then
-  exit $EXIT_FAILURE
-fi
+check_num_lines $MSG_NUM 4
 
 # action flag: we expect a different message from the action callback
 TIRED_MSG=`"$EXAMPLE" gallop --tired`
 check_strings "$TIRED_MSG" 'The pony is too tired to gallop.'
+
+# no action arguments specified: we expect an error message
+ARG_ERROR=`"$EXAMPLE" trot`
+check_strings "$ARG_ERROR" '''No arguments specified for trot.
+Failed to parse the command line input.'''
+
+# not all action arguments specified: we expect an error message
+ARG_ERROR=`"$EXAMPLE" trot foo`
+check_strings "$ARG_ERROR" '''Expected at least 2 parameters for action trot. Only read 1.
+Failed to parse the command line input.'''
+
+# action arguments: we expect it works with at least 2 arguments
+TROT_MSG_NUM=`"$EXAMPLE" trot 'world champion' panda rhino | grep Trotting | wc -l`
+check_num_lines $TROT_MSG_NUM 3


### PR DESCRIPTION
HorseWhisperer fails to process action arguments when the arity is
negative. Such values specifies the minimum number of arguments of a
given action.

This commit fixes HorseWhisperer; in case of an action with negative
arity, the parse function will now correctly validate the number of
arguments.
