### PR TITLE
(return codes) - Parse function return codes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,17 +313,33 @@ But when set inside the context of `gallop`
 ### Parsing commandline: global flags, actions, action flags, and action arguments
 
 When all flags and actions have been defined we are ready to parse the commandline and build
-a chain of contexts. The contexts contain the global flags, a list of actions and the order they should
-be called in as well as the flags used only by them.
+a chain of contexts. The contexts contain the global flags, a list of actions and the order
+they should be called in as well as the flags used only by them.
 
-    // bool Parse(int argc, char** argv)
+    // int Parse(int argc, char** argv)
     Parse(argc, argv); // The same argv and argc passed to main()
+
+The HorseWhisperer::Parse function will return an integer indicating the operation outcome.
+The possible return values are listed below, together with the related macro.
+
+    PARSE_OK = 0;             // success
+    PARSE_HELP = -1;          // help request
+    PARSE_VERSION = -2;       // version request
+    PARSE_ERROR = 1;          // failed to parse (e.g. missing argument)
+    PARSE_INVALID_FLAG = 2;   // invalid flag (e.g. string instead of an integer)
+
+### Displaying the help message
+
+If the HorseWhisperer::Parse function returns a PARSE_HELP value, you can simply call
+HorseWhisperer::ShowHelp to display the requested help message (global or action-specific).
 
 ### Validating action arguments
 
 When the commandline is parsed, you can trigger the execution of the optional action argument callbacks
 by calling HorseWhisperer::ValidateActionArguments(). In case any of of the callbacks return false,
 this function stops executing and returns false. It returns true otherwise.
+Also note that the validate function will always return false if HorseWhisperer::Parse did not
+return PARSE_OK previously.
 
     // bool ValidateActionArguments()
     ValidateActionArguments();
@@ -331,6 +347,8 @@ this function stops executing and returns false. It returns true otherwise.
 ### Executing actions
 
 When the commandline has been parsed starting your chain of action is as simple as calling the Start() function. Actions will continue to be executed until either the end of the list is reached or an action fails. When finished it will return the result of all the executed actions and'ed together (a return value of 0 means everything succeeded, 1 means the last attempt at executing an action failed).
+In case a previous HorseWhisperer::Parse call did not return PARSE_OK, the start function will
+immediately return 1, without executing any action callback.
 
     // int Start();
     return Start();

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,17 @@
 
 Change history for HorseWhisperer.
 
+# 0.3.0
+
+Released 2014-07-15
+
+* Improvements and update to example program and testing
+* The Parse function now returns an integer indicating its outcome
+* New function to display the help message
+* New function to display the version string
+* ValidateActionArguments now checks if Parse succeeded
+* The Start function now checks if Parse succeeded
+
 # 0.2.0
 
 Released 2014-07-09

--- a/examples/example1.cpp
+++ b/examples/example1.cpp
@@ -101,9 +101,21 @@ int main(int argc, char* argv[]) {
                  trot, trotArgumentsCallback);
 
     // Parse command line: global flags, action arguments, and action flags
-    if (!Parse(argc, argv)) {
-        std::cout << "Failed to parse the command line input.\n";
-        return 1;
+    switch (Parse(argc, argv)) {
+        case PARSE_OK:
+            break;
+        case PARSE_HELP:
+            ShowHelp();
+            return 0;
+        case PARSE_VERSION:
+            ShowVersion();
+            return 0;
+        case PARSE_ERROR:
+            std::cout << "Failed to parse the command line input.\n";
+            return 1;
+        case PARSE_INVALID_FLAG:
+            std::cout << "Invalid flag.\n";
+            return 2;
     }
 
     // Process and validate action arguments

--- a/test/system_test_runner.sh
+++ b/test/system_test_runner.sh
@@ -25,7 +25,7 @@ check_strings() {
   fi
 }
 
-check_num_lines() {
+check_numeric_pair() {
   if [ $1 -ne $2 ]; then
     exit $EXIT_FAILURE
   fi
@@ -45,7 +45,7 @@ check_strings "$ACTION_MSG" 'Galloping'
 
 # global flag: we expect the above message 4 times
 MSG_NUM=`"$EXAMPLE" gallop --ponies 4 | awk '{ if ( $1 ~ /Galloping/ ) {print $1} }' | wc -l`
-check_num_lines $MSG_NUM 4
+check_numeric_pair $MSG_NUM 4
 
 # action flag: we expect a different message from the action callback
 TIRED_MSG=`"$EXAMPLE" gallop --tired`
@@ -63,7 +63,7 @@ Failed to parse the command line input.'''
 
 # action arguments: we expect it works with at least 2 correct arguments
 TROT_MSG_NUM=`"$EXAMPLE" trot 'mode world champion' 'mode panda' 'mode rhino' | grep Trotting | wc -l`
-check_num_lines $TROT_MSG_NUM 3
+check_numeric_pair $TROT_MSG_NUM 3
 
 # invalid action arguments: we expect a validation error
 INVALID_ARG_ERROR=`"$EXAMPLE" trot 'mode world champion' panda`
@@ -77,5 +77,29 @@ Failed to validate the action arguments.'''
 
 # chaining works
 CHAINING_MSG=`"$EXAMPLE" gallop + trot 'mode one' 'mode two' 'mode three' --ponies 4`
-check_num_lines `echo "$CHAINING_MSG" | grep Galloping | wc -l` 4
-check_num_lines `echo "$CHAINING_MSG" | grep Trotting | wc -l` 3
+check_numeric_pair `echo "$CHAINING_MSG" | grep Galloping | wc -l` 4
+check_numeric_pair `echo "$CHAINING_MSG" | grep Trotting | wc -l` 3
+
+# return code: valid request
+"$EXAMPLE" gallop > /dev/null 2>&1
+check_numeric_pair $? 0
+
+# return code: fails to parse
+"$EXAMPLE" gallop "invalid_argument" > /dev/null 2>&1
+check_numeric_pair $? 1
+
+# return code: invalid flag type
+"$EXAMPLE" gallop --ponies "forty two" > /dev/null 2>&1
+check_numeric_pair $? 2
+
+# return code: help request
+"$EXAMPLE" --help > /dev/null 2>&1
+check_numeric_pair $? 0
+
+# return code: action help request
+"$EXAMPLE" trot --help > /dev/null 2>&1
+check_numeric_pair $? 0
+
+# return code: version request
+"$EXAMPLE" --version > /dev/null 2>&1
+check_numeric_pair $? 0


### PR DESCRIPTION
With this commit, the Parse function will return an integer indicating
the outcome of the parse operation.

Before this commit, the Parse function used to return a boolean value.
And, in case of a --help or --version flag, the function would display
the appropriate information.

Now, the function will return specific values. Also, it's up to the
caller to display the help message by executing the new ShowDisplay
function.
