### PR TITLE
Add GetParsedActions function

### DIFF
--- a/include/horsewhisperer/horsewhisperer.h
+++ b/include/horsewhisperer/horsewhisperer.h
@@ -490,6 +490,20 @@ class HorseWhisperer {
         throw undefined_flag_error { "undefined flag: " + name };
     };
 
+    std::vector<std::string> getParsedActions() {
+        std::vector<std::string> action_container {};
+
+        if (parsed_ && context_mgr.size() > 1) {
+            for (size_t i = 0; i < context_mgr.size(); i++) {
+                if (context_mgr[i]->action) {
+                    action_container.push_back(context_mgr[i]->action->name);
+                }
+            }
+        }
+
+        return action_container;
+    }
+
   private:
     int current_context_idx;
     std::vector<ContextPtr> context_mgr;
@@ -764,6 +778,10 @@ static void ShowHelp() {
 
 static void ShowVersion() {
     HorseWhisperer::Instance().version();
+}
+
+static std::vector<std::string> GetParsedActions() {
+    return HorseWhisperer::Instance().getParsedActions();
 }
 
 static int Start() {

--- a/test/unit/horsewhisperer_test.cpp
+++ b/test/unit/horsewhisperer_test.cpp
@@ -173,6 +173,30 @@ TEST_CASE("parse", "[parse]") {
     }
 }
 
+TEST_CASE("HorseWhisperer::getActions" "[getActions]") {
+    HW::Reset();
+    prepareGlobal();
+
+    HorseWhisperer::DefineAction("new_action_2", 0, false, "test-action", "no help",
+                                 [](std::vector<std::string>) -> int
+                                        { return 0; });
+
+    SECTION("returns a vector containing a single action name") {
+        const char* args[] = { "test-app", "new_action", "spam", "eggs" };
+        HW::Parse(4, const_cast<char**>(args));
+        REQUIRE(HW::GetParsedActions() == std::vector<std::string> { "new_action" });
+    }
+
+    SECTION("returns a vector containing a single action name") {
+        const char* args[] = { "test-app", "new_action", "spam", "eggs" "+",
+                               "new_action_2" };
+        std::vector<std::string> test_result { "new_action", "new_action_2" };
+        HW::Parse(6, const_cast<char**>(args));
+        REQUIRE(HW::GetParsedActions() == test_result);
+    }
+
+}
+
 TEST_CASE("HorseWhisperer::Start", "[start]") {
     HW::Reset();
     prepareGlobal();


### PR DESCRIPTION
This commit adds the GetParsedActions function that will return a vector
of actions present in parsed arguments.