### PR TITLE
Allow flags as key=value

### DIFF
--- a/include/horsewhisperer/horsewhisperer.h
+++ b/include/horsewhisperer/horsewhisperer.h
@@ -589,6 +589,16 @@ class HorseWhisperer {
         }
         std::string flagname(&argv[i][offset]);
 
+        // check if flag looks like key=value
+        size_t k_v { flagname.find("=") };
+
+        if (k_v != std::string::npos) {
+            flagname = flagname.substr(0, k_v);
+            // += offset to take - or -- into account
+            // increment to get the first char after '='
+            ++k_v += offset;
+        }
+
         //  Deal with special vlevel flags
         if (flagname[0] == 'v') {
             size_t vlevel = 0;
@@ -615,47 +625,66 @@ class HorseWhisperer {
             return PARSE_ERROR;
         }
 
-        switch (getFlagType(flagname)) {
-            case FlagType::Bool:
-                setFlag<bool>(flagname, true);
+        std::string value {};
+
+        FlagType flag_type = getFlagType(flagname);
+
+        if (k_v != std::string::npos) {
+            value = &argv[i][k_v];
+        } else if (flag_type != FlagType::Bool && argv[++i]) {
+            // bool shouldn't try and take an argument from argv
+            value = argv[i];
+        }
+
+        return setAndValidateFlag(flag_type, flagname, value);
+    }
+
+    int setAndValidateFlag(FlagType flag_type, std::string flagname,
+                           std::string value) {
+        if (flag_type == FlagType::Bool) {
+            bool b_val { true };
+
+            if (!value.empty()) {
+                // passed as --true_thing=false|true
+                if (value == "false") {
+                    b_val = false;
+                } else if (value != "true") {
+                    std::cout << "Flag '" << flagname
+                              << "' expects a value of 'true' or 'false'"
+                              << std::endl;
+                    return PARSE_ERROR;
+                }
+            }
+            setFlag<bool>(flagname, b_val);
+            return PARSE_OK;
+        } else {
+            if (value.empty()) {
+                std::cout << "Missing value for flag: " << flagname << std::endl;
+                return PARSE_ERROR;
+            }
+
+            if (flag_type == FlagType::String) {
+                setFlag<std::string>(flagname, std::string(value));
                 return PARSE_OK;
-            case FlagType::String:
-                if (argv[++i]) {
-                    setFlag<std::string>(flagname, std::string(argv[i]));
+            } else if (flag_type == FlagType::Int) {
+                if (validateInteger(value)) {
+                    setFlag<int>(flagname, std::stol(value, nullptr, 10));
                     return PARSE_OK;
                 } else {
-                    std::cout << "Missing value for flag: " << argv[i-1] << std::endl;
-                    return PARSE_ERROR;
+                    std::cout << "Flag '" << flagname
+                                << "' expects a value of type integer" << std::endl;
+                    return PARSE_INVALID_FLAG;
                 }
-            case FlagType::Int:
-                if (argv[++i]) {
-                    // Validate string looks like an interger
-                    if (validateInteger(argv[i])) {
-                        setFlag<int>(flagname, std::stol(argv[i], nullptr, 10));
-                        return PARSE_OK;
-                    } else {
-                        std::cout << "Flag '" << flagname
-                                  << "' expects a value of type integer" << std::endl;
-                        return PARSE_INVALID_FLAG;
-                    }
+            } else if (flag_type == FlagType::Double) {
+                if (validateDouble(value)) {
+                    setFlag<double>(flagname, std::stod(value));
+                    return PARSE_OK;
                 } else {
-                    std::cout << "Missing value for flag: " << argv[i-1] << std::endl;
-                    return PARSE_ERROR;
+                    std::cout << "Flag '" << flagname
+                              << "' expects a value of type double" << std::endl;
+                    return PARSE_INVALID_FLAG;
                 }
-            case FlagType::Double:
-                if (argv[++i]) {
-                    if (validateDouble(argv[i])) {
-                        setFlag<double>(flagname, std::stod(argv[i]));
-                        return PARSE_OK;
-                    } else {
-                        std::cout << "Flag '" << flagname
-                                  << "' expects a value of type double" << std::endl;
-                        return PARSE_INVALID_FLAG;
-                    }
-                } else {
-                    std::cout << "Missing value for flag: " << argv[i-1] << std::endl;
-                    return PARSE_ERROR;
-                }
+            }
         }
 
         std::cout << flagname << " is not of a valid flag type." << std::endl;

--- a/test/unit/horsewhisperer_test.cpp
+++ b/test/unit/horsewhisperer_test.cpp
@@ -216,6 +216,20 @@ TEST_CASE("parse", "[parse]") {
         REQUIRE(HW::Parse(4, const_cast<char**>(args)) == HW::PARSE_INVALID_FLAG);
     }
 
+    SECTION("returns PARSE_OK when mixing key=value and other flags") {
+        HW::DefineGlobalFlag<int>("foo", "a int test flag", 0, nullptr);
+        HW::DefineGlobalFlag<bool>("bar", "a bool test flag", false, nullptr);
+
+        const char* args[] = { "test-app", "test-action", "--bar", "--foo=5" };
+        REQUIRE(HW::Parse(4, const_cast<char**>(args)) == HW::PARSE_OK);
+    }
+
+    SECTION("returns PARSE_OK when flag is given as key=value") {
+        HW::DefineGlobalFlag<int>("foo", "a test flag", 0, nullptr);
+        const char* args[] = { "test-app", "test-action", "--foo=5" };
+        REQUIRE(HW::Parse(3, const_cast<char**>(args)) == HW::PARSE_OK);
+    }
+
     HW::DefineAction("new_action", 2, false, "test action", "2 args required!",
                      testActionCallback);
 


### PR DESCRIPTION
In the past passing a flag like --key=value would cause an invalid flag
to be parsed.

In this commit we extend the flag parser to allow flags like --key=value