### PR TITLE
(maint) do not define NDEBUG

### DIFF
--- a/include/horsewhisperer/horsewhisperer.h
+++ b/include/horsewhisperer/horsewhisperer.h
@@ -13,9 +13,6 @@
 #include <functional>
 #include <memory>
 #include <stdexcept>
-
-// To disable assert()
-#define NDEBUG
 #include <cassert>
 
 


### PR DESCRIPTION
cmake when building a "Release" target will specify -DNDEBUG=1 and
leave it unset at all other times.  That means we shouldn't actually
define it here as we are overriding user wishes, and also causing an
error or warning via -Wmacro-redefined.

If we're sure we never want the user to run with assertions enabled,
then we could gate this like so:

    #ifndef NDEBUG
    // We don't want assert() to be functional
    #define NDEBUG
    #endif  // NDEBUG

Instead here we assume that a user can enable/disable assertions if they want
to, so get out of the business of disabling assertions.