### PR TITLE
Start function should not throw if missing action callback

### DIFF
--- a/test/unit/horsewhisperer_test.cpp
+++ b/test/unit/horsewhisperer_test.cpp
@@ -353,6 +353,12 @@ TEST_CASE("HorseWhisperer::Start", "[start]") {
     HW::Reset();
     prepareGlobal();
 
+    SECTION("returns false in case of missing action callback") {
+        HW::DefineAction("start_test_1", 0, false, "test-action", "no help",
+                         nullptr);
+        REQUIRE(!HW::Start());
+    }
+
     SECTION("it executes an action") {
         int modify_me = 0;
         HW::DefineAction("start_test_1", 0, false, "test-action", "no help",


### PR DESCRIPTION
HorseWhisperer::Start() was not checking if the callback of a given
action was defined before trying to execute it; an unexpected error
was thrown in such case. We now display an error message on stdout
and prevent possible chained actions form starting.