### PR TITLE
Rename ParseResult::ERROR to ParseResult::FAILURE

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ The possible return values are listed below.
     ParseResult::OK;            // success
     ParseResult::HELP;          // help request
     ParseResult::VERSION;       // version request
-    ParseResult::ERROR;         // failed to parse (e.g. missing argument)
+    ParseResult::FAILURE;       // failed to parse (e.g. missing argument)
     ParseResult::INVALID_FLAG;  // invalid flag (e.g. string instead of an integer)
 
 When parsing a given flag value, the releavant flag validation callback will be executed and a `flag_validation_error` may be thrown.

--- a/examples/example1.cpp
+++ b/examples/example1.cpp
@@ -95,7 +95,7 @@ int main(int argc, char* argv[]) {
             case ParseResult::VERSION:
                 ShowVersion();
                 return 0;
-            case ParseResult::ERROR:
+            case ParseResult::FAILURE:
                 std::cout << "Failed to parse the command line input.\n";
                 return 1;
             case ParseResult::INVALID_FLAG:

--- a/include/horsewhisperer/horsewhisperer.h
+++ b/include/horsewhisperer/horsewhisperer.h
@@ -57,7 +57,7 @@ static const int GLOBAL_CONTEXT_IDX = 0;
 static const int NO_CONTEXT_IDX = -1;
 
 // Parse results
-enum class ParseResult { OK, HELP, VERSION, ERROR, INVALID_FLAG };
+enum class ParseResult { OK, HELP, VERSION, FAILURE, INVALID_FLAG };
 
 // Margins for help descriptions
 static const unsigned int DESCRIPTION_MARGIN_LEFT_DEFAULT = 30;
@@ -430,11 +430,11 @@ class HorseWhisperer {
                             } else if (isActionDefined(argv[arg_idx])) {  // is it an action?
                                 std::cout << "Expected parameter for action: " << action
                                           << ". Found action: " << argv[arg_idx] << std::endl;
-                                return ParseResult::ERROR;
+                                return ParseResult::FAILURE;
                             } else if (isDelimiter(argv[arg_idx])) {  // is it a delimiter?
                                 std::cout << "Expected parameter for action: " << action
                                           << ". Found delimiter: " << argv[arg_idx] << std::endl;
-                                return ParseResult::ERROR;
+                                return ParseResult::FAILURE;
                             } else {
                                 context_mgr_[current_context_idx_]->arguments
                                     .push_back(argv[arg_idx]);
@@ -448,7 +448,7 @@ class HorseWhisperer {
                                       << " parameters for action " << action << ". Only read "
                                       << context_mgr_[current_context_idx_]->action->arity - arity
                                       << "." << std::endl;
-                            return ParseResult::ERROR;
+                            return ParseResult::FAILURE;
                         }
                     } else {
                         // When arity is an "at least" representation we eat arguments
@@ -480,12 +480,12 @@ class HorseWhisperer {
                                       << " parameters for action " << action << ". Only read "
                                       << context_mgr_[current_context_idx_]->action->arity - arity
                                       << "." << std::endl;
-                            return ParseResult::ERROR;
+                            return ParseResult::FAILURE;
                         }
                     }
                 } else {
                     std::cout << "Unknown action: " << argv[arg_idx] << std::endl;
-                    return ParseResult::ERROR;
+                    return ParseResult::FAILURE;
                 }
             }
         }
@@ -816,7 +816,7 @@ class HorseWhisperer {
 
         if (!isFlagDefined(flagname)) {
             std::cout << "Unknown flag: " << flagname << std::endl;
-            return ParseResult::ERROR;
+            return ParseResult::FAILURE;
         }
 
         FlagType flag_type = checkAndGetTypeOfFlag(flagname);
@@ -846,7 +846,7 @@ class HorseWhisperer {
                     std::cout << "Flag '" << flagname
                               << "' expects a value of 'true' or 'false'"
                               << std::endl;
-                    return ParseResult::ERROR;
+                    return ParseResult::FAILURE;
                 }
             }
             setFlag<bool>(flagname, b_val);
@@ -854,7 +854,7 @@ class HorseWhisperer {
         } else {
             if (value.empty()) {
                 std::cout << "Missing value for flag: " << flagname << std::endl;
-                return ParseResult::ERROR;
+                return ParseResult::FAILURE;
             }
 
             if (flag_type == FlagType::String) {
@@ -882,7 +882,7 @@ class HorseWhisperer {
         }
 
         std::cout << flagname << " is not of a valid flag type." << std::endl;
-        return ParseResult::ERROR;
+        return ParseResult::FAILURE;
     }
 
     // Display help information for the global context

--- a/test/unit/horsewhisperer_test.cpp
+++ b/test/unit/horsewhisperer_test.cpp
@@ -253,9 +253,9 @@ TEST_CASE("parse", "[parse]") {
         REQUIRE(HW::Parse(3, const_cast<char**>(args)) == HW::ParseResult::VERSION);
     }
 
-    SECTION("returns PARSE_EERROR on bad arguments") {
+    SECTION("returns PARSE_FAILURE on bad arguments") {
         const char* args[] = { "test-app", "test-action", "test-smachtions", nullptr };
-        REQUIRE(HW::Parse(3, const_cast<char**>(args)) == HW::ParseResult::ERROR);
+        REQUIRE(HW::Parse(3, const_cast<char**>(args)) == HW::ParseResult::FAILURE);
     }
 
     SECTION("returns ParseResult::INVALID_FLAG on a bad flag") {
@@ -282,21 +282,21 @@ TEST_CASE("parse", "[parse]") {
         HW::DefineAction("no_arg_action", 0, false, "test action",
                          "no arg required!", testActionCallback);
 
-        SECTION("returns ParseResult::ERROR if an argument is passed") {
+        SECTION("returns ParseResult::FAILURE if an argument is passed") {
             const char* args[] = { "test-app", "no_arg_action", "bad_arg", nullptr };
-            REQUIRE(HW::Parse(3, const_cast<char**>(args)) == HW::ParseResult::ERROR);
+            REQUIRE(HW::Parse(3, const_cast<char**>(args)) == HW::ParseResult::FAILURE);
         }
 
-        SECTION("returns ParseResult::ERROR if an argument/flag are passed") {
+        SECTION("returns ParseResult::FAILURE if an argument/flag are passed") {
             const char* args[] = { "test-app", "no_arg_action", "bad_arg",
                                    "--verbose", nullptr };
-            REQUIRE(HW::Parse(4, const_cast<char**>(args)) == HW::ParseResult::ERROR);
+            REQUIRE(HW::Parse(4, const_cast<char**>(args)) == HW::ParseResult::FAILURE);
         }
 
-        SECTION("returns ParseResult::ERROR if an flag/argument are passed") {
+        SECTION("returns ParseResult::FAILURE if an flag/argument are passed") {
             const char* args[] = { "test-app", "no_arg_action", "--verbose",
                                    "bad_arg", nullptr };
-            REQUIRE(HW::Parse(4, const_cast<char**>(args)) == HW::ParseResult::ERROR);
+            REQUIRE(HW::Parse(4, const_cast<char**>(args)) == HW::ParseResult::FAILURE);
         }
 
         SECTION("returns ParseResult::OK if no action argument is provided") {
@@ -314,21 +314,21 @@ TEST_CASE("parse", "[parse]") {
         HW::DefineAction("two_args_action", 2, false, "test action",
                          "2 args required!", testActionCallback);
 
-        SECTION("returns ParseResult::ERROR if no argument is passed") {
+        SECTION("returns ParseResult::FAILURE if no argument is passed") {
             const char* args[] = { "test-app", "two_args_action", nullptr };
-            REQUIRE(HW::Parse(2, const_cast<char**>(args)) == HW::ParseResult::ERROR);
+            REQUIRE(HW::Parse(2, const_cast<char**>(args)) == HW::ParseResult::FAILURE);
         }
 
-        SECTION("return ParseResult::ERROR if one action argument is missing") {
+        SECTION("return ParseResult::FAILURE if one action argument is missing") {
             const char* args[] = { "test-app", "two_args_action", "spam", nullptr };
-            REQUIRE(HW::Parse(3, const_cast<char**>(args)) == HW::ParseResult::ERROR);
+            REQUIRE(HW::Parse(3, const_cast<char**>(args)) == HW::ParseResult::FAILURE);
         }
 
-        SECTION("returns ParseResult::ERROR if one action arguments is missing and a "
+        SECTION("returns ParseResult::FAILURE if one action arguments is missing and a "
                 "flag is passed") {
             const char* args[] = { "test-app", "two_args_action", "spam",
                                    "--verbose", nullptr };
-            REQUIRE(HW::Parse(4, const_cast<char**>(args)) == HW::ParseResult::ERROR);
+            REQUIRE(HW::Parse(4, const_cast<char**>(args)) == HW::ParseResult::FAILURE);
         }
 
         SECTION("returns ParseResult::OK if all action arguments are provided") {
@@ -377,15 +377,15 @@ TEST_CASE("parse", "[parse]") {
                              "more than 2 args required!", testActionCallback,
                              nullptr, true);
 
-            SECTION("returns ParseResult::ERROR if no action arguments is passed") {
+            SECTION("returns ParseResult::FAILURE if no action arguments is passed") {
                 const char* args[] = { "test-app", "two_or_more_args_action", nullptr };
-                REQUIRE(HW::Parse(2, const_cast<char**>(args)) == HW::ParseResult::ERROR);
+                REQUIRE(HW::Parse(2, const_cast<char**>(args)) == HW::ParseResult::FAILURE);
             }
 
-            SECTION("return ParseResult::ERROR if one action argument is missing") {
+            SECTION("return ParseResult::FAILURE if one action argument is missing") {
                 const char* args[] = { "test-app", "two_or_more_args_action",
                                        "spam", nullptr };
-                REQUIRE(HW::Parse(3, const_cast<char**>(args)) == HW::ParseResult::ERROR);
+                REQUIRE(HW::Parse(3, const_cast<char**>(args)) == HW::ParseResult::FAILURE);
             }
 
             SECTION("returns ParseResult::OK if 2 action arguments are provided") {
@@ -445,7 +445,7 @@ TEST_CASE("parse", "[parse]") {
             REQUIRE(HW::Parse(12, const_cast<char**>(args)) == HW::ParseResult::OK);
         }
 
-        SECTION("correctly return ParseResult::ERROR") {
+        SECTION("correctly return ParseResult::FAILURE") {
             const char* args[] = { "test-app",
                                    "no_arg_action",
                                    "no_arg_action", "bad_arg",  // error
@@ -453,7 +453,7 @@ TEST_CASE("parse", "[parse]") {
                                    "var_args_action", "spam", "eggs",
                                    "var_args_action",
                                    "two_or_more_args_action", "a", "b", "c", nullptr };
-            REQUIRE(HW::Parse(15, const_cast<char**>(args)) == HW::ParseResult::ERROR);
+            REQUIRE(HW::Parse(15, const_cast<char**>(args)) == HW::ParseResult::FAILURE);
         }
 
         SECTION("correctly return ParseResult::OK with variable args actions") {


### PR DESCRIPTION
ERROR is a defined macro on Windows. Here we rename ERROR to FAILURE so
HW can be included on Windows without blowing up.