### PR TITLE
Always show short options with single dash

### DIFF
--- a/include/horsewhisperer/horsewhisperer.h
+++ b/include/horsewhisperer/horsewhisperer.h
@@ -960,7 +960,7 @@ class HorseWhisperer {
             if (alias != "") {
                 output << "\n";
                 output << std::setw(description_margin_left_) << std::left;
-                last_alias_size = alias.size() + arg.size();
+                last_alias_size = alias.size();
 
                 if (last_alias_size == 1) {
                     output << "   -" + alias + arg;


### PR DESCRIPTION
The help text for the short version of an option that accepts an argument
would still display with -- instead of -. Test only the alias size to use a
single dash.