### PR TITLE
Allow a short flag for "version"

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ will change the version message to
     $ myprog --version
     MyProg version - 0.1.0
 
+A short flag for the version can be supplied as the second argument:
+
+    // void SetVersion(std::string version, std::string short_flag);
+    HorseWhisperer::SetVersion("MyProg version - 0.1.0\n", "V");
+
+will allow the invocation
+
+    $ myprog -V
+    MyProg version - 0.1.0
+
 Finally, a word on delimiters. By default Horse Whisperer has no delimiting symbols and chaining commands
 is done simply by following up one command with another. There are certain cases where this behaviour is not optimal, so it is posible to define delimitors with the *SetDelimters* function. Note that it is not advised to use a dash as
 a delimeter; dashes are used to identify flags.

--- a/include/horsewhisperer/horsewhisperer.h
+++ b/include/horsewhisperer/horsewhisperer.h
@@ -204,7 +204,7 @@ static void DefineAction(std::string action_name,
                          bool variable_arity) __attribute__ ((unused));
 static void SetAppName(std::string name) __attribute__ ((unused));
 static void SetHelpBanner(std::string banner) __attribute__ ((unused));
-static void SetVersion(std::string version) __attribute__ ((unused));
+static void SetVersion(std::string version, std::string short_flag) __attribute__ ((unused));
 static void SetDelimiters(std::vector<std::string> delimiters) __attribute__ ((unused));
 static ParseResult Parse(int argc, char** argv) __attribute__ ((unused));
 static void ShowHelp() __attribute__ ((unused));
@@ -316,9 +316,14 @@ class HorseWhisperer {
         help_banner_ = banner;
     }
 
-    void setVersionString(std::string version_string) {
+    void setVersionString(std::string version_string, std::string short_flag_string) {
         version_string_ = version_string;
-        defineGlobalFlag<bool>("version", "Display version information", false,
+        version_short_flag_string_ = short_flag_string;
+        std::string flag_string = "version";
+        if (short_flag_string != "") {
+            flag_string = short_flag_string + " " + flag_string;
+        }
+        defineGlobalFlag<bool>(flag_string, "Display version information", false,
                                nullptr);
     }
 
@@ -745,6 +750,7 @@ class HorseWhisperer {
 
     // Version information
     std::string version_string_;
+    std::string version_short_flag_string_;
 
     // Margins, indicated as number of columns
     unsigned int description_margin_left_;
@@ -768,6 +774,7 @@ class HorseWhisperer {
         application_name_ = "";
         help_banner_ = "";
         version_string_ = "";
+        version_short_flag_string_ = "";
         description_margin_left_ = DESCRIPTION_MARGIN_LEFT_DEFAULT;
         description_margin_right_ = DESCRIPTION_MARGIN_RIGHT_DEFAULT;
 
@@ -816,7 +823,7 @@ class HorseWhisperer {
         }
 
         // Deal with the special --version flag
-        if (flagname == "version") {
+        if (flagname == "version" || flagname == version_short_flag_string_) {
             return ParseResult::VERSION;
         }
 
@@ -1125,8 +1132,8 @@ static void SetHelpBanner(std::string banner) {
     HorseWhisperer::Instance().setHelpBanner(banner);
 }
 
-static void SetVersion(std::string version_string) {
-    HorseWhisperer::Instance().setVersionString(version_string);
+static void SetVersion(std::string version_string, std::string short_flag_string = "") {
+    HorseWhisperer::Instance().setVersionString(version_string, short_flag_string);
 }
 
 static void SetDelimiters(std::vector<std::string> delimiters) {

--- a/test/unit/horsewhisperer_test.cpp
+++ b/test/unit/horsewhisperer_test.cpp
@@ -253,6 +253,18 @@ TEST_CASE("parse", "[parse]") {
         REQUIRE(HW::Parse(3, const_cast<char**>(args)) == HW::ParseResult::VERSION);
     }
 
+    SECTION("returns ParseResult::VERSION without short flag") {
+        HW::SetVersion("1.1");
+        const char* args[] = { "test-app", "test-action", "--version", nullptr };
+        REQUIRE(HW::Parse(3, const_cast<char**>(args)) == HW::ParseResult::VERSION);
+    }
+
+    SECTION("returns ParseResult::VERSION on the short flag") {
+        HW::SetVersion("1.1", "V");
+        const char* args[] = { "test-app", "test-action", "-V", nullptr };
+        REQUIRE(HW::Parse(3, const_cast<char**>(args)) == HW::ParseResult::VERSION);
+    }
+
     SECTION("returns PARSE_FAILURE on bad arguments") {
         const char* args[] = { "test-app", "test-action", "test-smachtions", nullptr };
         REQUIRE(HW::Parse(3, const_cast<char**>(args)) == HW::ParseResult::FAILURE);


### PR DESCRIPTION
In order to grant applications a bit more flexibility in the stock global flags,
a short string can be allowed for specifying the version.