### PR TITLE
Allow shared libraries to export configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ The Horse Whisperer can be used in your code by simply including the header file
 It is implemented as a singleton object and in most cases it is expected to exist for the
 duration of of the program invoking it.
 
+Note: To use the singleton object across shared library boundaries when compiling with
+visibility attributes, define HORSEWHISPERER\_EXPORT.
+
 When first referencing the singleton three flags will be created for you by default.
 
  * --help

--- a/include/horsewhisperer/horsewhisperer.h
+++ b/include/horsewhisperer/horsewhisperer.h
@@ -14,6 +14,10 @@
 #include <stdexcept>
 #include <cassert>
 
+// Used by consumers to export Horsewhisperer configuration from a shared library.
+#ifndef HORSEWHISPERER_EXPORT
+#define HORSEWHISPERER_EXPORT
+#endif
 
 namespace HorseWhisperer {
 
@@ -288,7 +292,7 @@ static FlagType getTypeOfFlag(const FlagBase* flagp) {
 // HorseWhisperer
 //
 
-class HorseWhisperer {
+class HORSEWHISPERER_EXPORT HorseWhisperer {
   public:
     // Return reference to instance of HorseWhisperer singleton
     static HorseWhisperer& Instance() {


### PR DESCRIPTION
Without this change, shared libraries that configure command-line flags
hide that configuration so an external consumer can't access or update
it. Allow the singleton class to be configured for symbol visibility
attributes to allow use externally from a shared library.