### PR TITLE
Fix memory leaks, add MultiString type

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ Supported flag types are:
 | Int | `int` |
 | Double | `double` |
 | String | `std::string` |
+| MultiString | `std::vector<std::string>` |
+
+MultiString allows multiple values to be specified, separated by spaces. It takes all values
+following the flag until encountering another flag or action. That comes with a few caveats for users:
+ * A MultiString flag cannot accept values with leading hyphens (i.e. -3.14)
+ * A MultiString flag should follow any arguments to an action
 
 If the incorrect type is used - such as `SetFlag<bool>("flag", true); GetFlag<double>("flag")` - you
 may encounter memory corruption.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ At any point after declaring a flag it's value can be set or looked up by the fo
     template <typename FlagType>
     bool SetFlag(std::string flag_name, FlagType value)
 
+Supported flag types are:
+
+| FlagType | primitive |
+| --- | --- |
+| Bool | `bool` |
+| Int | `int` |
+| Double | `double` |
+| String | `std::string` |
+
+If the incorrect type is used - such as `SetFlag<bool>("flag", true); GetFlag<double>("flag")` - you
+may encounter memory corruption.
+
 The Horse Whisperer will throw an "undefined_flag_error" exception when trying to apply GetFlag or
 SetFlag to an undefined flag.
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 Change history for HorseWhisperer.
 
+# 0.13.0
+
+Released 2016-06-20
+
+* Fixed memory leaks
+* Add a MultiString type for taking a list of string arguments. See
+the README for caveats about using it.
+
 # 0.12.1
 
 Released 2015-06-01

--- a/include/horsewhisperer/horsewhisperer.h
+++ b/include/horsewhisperer/horsewhisperer.h
@@ -53,7 +53,7 @@ class action_validation_error : public horsewhisperer_error {
 // Tokens
 //
 
-static const std::string VERSION_STRING = "0.12.1";
+static const std::string VERSION_STRING = "0.13.0";
 
 // Context indexes
 static const int GLOBAL_CONTEXT_IDX = 0;

--- a/include/horsewhisperer/horsewhisperer.h
+++ b/include/horsewhisperer/horsewhisperer.h
@@ -189,11 +189,11 @@ static void DefineActionFlag(std::string action_name,
                              FlagCallback<Type> flag_callback) __attribute__ ((unused));
 static bool IsActionFlag(std::string action, std::string flagname) __attribute__ ((unused));
 template <typename Type>
-static Type GetFlag(std::string flag_name) __attribute__ ((unused));
+static Type GetFlag(std::string const& flag_name) __attribute__ ((unused));
 // Throws undefined_flag_error in case the specified flag is unknown
-static FlagType GetFlagType(std::string flag_name) __attribute__ ((unused));
+static FlagType GetFlagType(std::string const& flag_name) __attribute__ ((unused));
 template <typename Type>
-static void SetFlag(std::string flag_name, Type value) __attribute__ ((unused));
+static void SetFlag(std::string const& flag_name, Type value) __attribute__ ((unused));
 static void DefineAction(std::string action_name,
                          int arity,
                          bool chainable,
@@ -205,7 +205,7 @@ static void DefineAction(std::string action_name,
 static void SetAppName(std::string name) __attribute__ ((unused));
 static void SetHelpBanner(std::string banner) __attribute__ ((unused));
 static void SetVersion(std::string version, std::string short_flag) __attribute__ ((unused));
-static void SetDelimiters(std::vector<std::string> delimiters) __attribute__ ((unused));
+static void SetDelimiters(std::vector<std::string> const& delimiters) __attribute__ ((unused));
 static ParseResult Parse(int argc, char** argv) __attribute__ ((unused));
 static void ShowHelp(bool show_actions_help = true) __attribute__ ((unused));
 static void ShowVersion() __attribute__ ((unused));
@@ -646,7 +646,7 @@ class HORSEWHISPERER_EXPORT HorseWhisperer {
     }
 
     template <typename Type>
-    Type getFlagValue(std::string name) throw (undefined_flag_error) {
+    Type getFlagValue(std::string const& name) throw (undefined_flag_error) {
         int context_idx = getContextIdxIfDefined(name);
         if (context_idx != NO_CONTEXT_IDX) {
             return std::static_pointer_cast<Flag<Type>>(context_mgr_[context_idx]->flags[name])->value;
@@ -667,8 +667,8 @@ class HORSEWHISPERER_EXPORT HorseWhisperer {
 
     // ALSO check both contexts
     template <typename Type>
-    void setFlag(std::string name, Type value) throw (undefined_flag_error,
-                                                      flag_validation_error) {
+    void setFlag(std::string const& name, Type value) throw (undefined_flag_error,
+                                                             flag_validation_error) {
         int context_idx = getContextIdxIfDefined(name);
         if (context_idx != NO_CONTEXT_IDX) {
             auto flagp = std::static_pointer_cast<Flag<Type>>(
@@ -1051,7 +1051,7 @@ class HORSEWHISPERER_EXPORT HorseWhisperer {
         }
     }
 
-    int getContextIdxIfDefined(std::string name) {
+    int getContextIdxIfDefined(std::string const& name) {
         if (context_mgr_[current_context_idx_]->flags.find(name)
                 != context_mgr_[current_context_idx_]->flags.end()) {
             return current_context_idx_;
@@ -1101,27 +1101,27 @@ static void DefineActionFlag(std::string action_name,
 }
 
 template <typename Type>
-static Type GetFlag(std::string flag_name) {
+static Type GetFlag(std::string const& flag_name) {
     return HorseWhisperer::Instance().getFlagValue<Type>(flag_name);
 }
 
-static FlagType GetFlagType(std::string flag_name) {
+static FlagType GetFlagType(std::string const& flag_name) {
     return HorseWhisperer::Instance().checkAndGetTypeOfFlag(flag_name);
 }
 
 template <typename Type>
-static void SetFlag(std::string flag_name, Type value) {
-    HorseWhisperer::Instance().setFlag<Type>(flag_name, value);
+static void SetFlag(std::string const& flag_name, Type value) {
+    HorseWhisperer::Instance().setFlag<Type>(flag_name, std::move(value));
 }
 
 static void DefineAction(std::string action_name,
-                           int arity,
-                           bool chainable,
-                           std::string description,
-                           std::string help_string,
-                           ActionCallback action_callback,
-                           ArgumentsCallback arguments_callback = nullptr,
-                           bool variable_arity = false) {
+                         int arity,
+                         bool chainable,
+                         std::string description,
+                         std::string help_string,
+                         ActionCallback action_callback,
+                         ArgumentsCallback arguments_callback = nullptr,
+                         bool variable_arity = false) {
     HorseWhisperer::Instance().defineAction(action_name,
                                             arity,
                                             chainable,
@@ -1148,7 +1148,7 @@ static void SetVersion(std::string version_string, std::string short_flag_string
     HorseWhisperer::Instance().setVersionString(version_string, short_flag_string);
 }
 
-static void SetDelimiters(std::vector<std::string> delimiters) {
+static void SetDelimiters(std::vector<std::string> const& delimiters) {
     HorseWhisperer::Instance().setDelimiters(delimiters);
 }
 

--- a/test/README.md
+++ b/test/README.md
@@ -13,7 +13,7 @@ It must be compiled; the executable must be named `example` and stored in the
 Unit Tests
 ---
 
-The unit tests for Horse Whisperere are based on the
+The unit tests for Horse Whisperer are based on the
 [Catch framework](https://github.com/philsquared/Catch).
 
 To run the tests, simply execute:


### PR DESCRIPTION
**Cleanup memory usage by using shared_ptr**
Fix memory leaks by using std::shared_ptr. Leaks found using valgrind.

**Implement MultiString type**
Adds a MultiString type that reads arguments until the next flag or known subcommand, and provides them as a vector of strings.

**Prepare for 0.13.0 release**